### PR TITLE
3.1.0 - give-multimoeda (Compatibilidade com o método de pagamento Paypal)

### DIFF
--- a/Includes/GiveMultiCurrencyActions.php
+++ b/Includes/GiveMultiCurrencyActions.php
@@ -104,7 +104,7 @@ final class GiveMultiCurrencyActions
      */
     public static function lkn_give_multi_currency_get_active_currency()
     {
-        $currencies = give_get_option('multi_currency_active_currency');
+        $currencies = give_get_option('multi_currency_active_currency', []);
         $defaultCurrency = strtolower(give_get_option('multi_currency_default_currency'));
 
         $currencies = array_values(array_filter($currencies, function ($item) use ($defaultCurrency) {


### PR DESCRIPTION
> Correção na conversão de moeda durante o processo de pagamento Paypal.

![image](https://github.com/user-attachments/assets/ca8ce225-ba4f-4ac5-9445-60e1a8da8174)

* No momento em que o pagamento for realizado através de outro tipo de moeda, será realizado uma conversão para moeda padrão antes do pagamento. 

> Correção no moeda padrão nas configurações do select:

![image](https://github.com/user-attachments/assets/38fbf4f3-6128-4c20-890e-cce39c3a639d)

![image](https://github.com/user-attachments/assets/31b2b043-fc9e-4654-b194-ac9b21d3078b)

* Ao selecionar o tipo de moeda habilitada, as configurações irá detectar a moeda padrão selecionada e adaptar o select para o preenchimento. 
