### PR TITLE
3.1.2 - give-multimoeda (Atualização do script no momento da geração do botão Paypal) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Prepare plugin folder
       run: |
         mkdir -p dist
-        mkdir -p build
-        mv ./Admin ./Includes ./resource *.php *.txt ./build
-        cp -r vendor build/vendor
+        mkdir -p build/${{ env.PLUGIN_NAME }}
+        mv ./Admin ./Includes ./resource *.php *.txt ./build/${{ env.PLUGIN_NAME }}
+        cp -r vendor ./build/${{ env.PLUGIN_NAME }}/vendor
         find ./build -type f -exec chmod 0644 {} +
         find ./build -type d -exec chmod 0755 {} +
 
@@ -57,7 +57,7 @@ jobs:
       uses: mathieudutour/github-tag-action@v6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        custom_tag: '3.1.1'
+        custom_tag: '3.1.2'
 
     # Generate new release
     - name: Generate new Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.2 - 02/05/2025
+* Correção no action.
+
 # 3.1.1 - 23/04/2025
 * Atualização do script Paypal.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Pronto! Você realizou sua primeira doação via plugin do multimoedas.
 
 ## Changelog
 
+### 3.1.2 - 02/05/2025
+* Correção no action.
+
 ### 3.1.1 - 23/04/2025
 * Atualização do script Paypal.
 

--- a/give-currency.php
+++ b/give-currency.php
@@ -4,7 +4,7 @@
  * Plugin Name: Give - Multi-Moedas
  * Plugin URI:  https://www.linknacional.com.br/wordpress/givewp/multimoeda/
  * Description: Adiciona opções de escolha de moedas aos formulários do GiveWP.
- * Version:     3.1.1
+ * Version:     3.1.2
  * Author:      Link Nacional
  * Requires Plugins: give
  * Author URI:  https://www.linknacional.com.br
@@ -23,7 +23,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 use Lkn\GiveMultimoedas\Includes\GiveMultiCurrency;
 
 if (! defined('GIVE_MULTI_CURRENCY_VERSION')) {
-    define('GIVE_MULTI_CURRENCY_VERSION', '3.1.1');
+    define('GIVE_MULTI_CURRENCY_VERSION', '3.1.2');
 }
 
 // Set it to latest.


### PR DESCRIPTION
# Give Multimoeda

Contribuidores: linknacional

Link: https://www.linknacional.com.br/wordpress/

Tags: givewp, cielo, give, payment, linknacional

Testado até: 6.7.2

Versão estável: 3.1.2

Licença: GPLv2 ou posterior

URI da Licença: http://www.gnu.org/licenses/gpl-2.0.html

Traduções: Português(Brasil)

## Descrição

O [GiveWP Multi-Moeda](https://www.linknacional.com.br/wordpress/givewp/multimoeda/) é um plugin para a plataforma de doação GiveWP que tem o objetivo de fazer a conversão da moeda estrangeira para a moeda nacional (BRL) a fim de realizar um determinado pagamento internacional e o mesmo ser reconhecido pelos processadores de pagamento do Brasil.

## Instalação

1. Baixe o plugin.
2. No painel administrativo do WordPress, vá para Plugins > Adicionar Novo.
3. Clique em "Enviar Plugin" e selecione o arquivo ZIP do plugin que você baixou.
4. Clique em "Instalar Agora" e, em seguida, em "Ativar Plugin".

## Resumo(3.1.2):

> Correção no script de geração do botão do método de pagamento Paypal.

![image](https://github.com/user-attachments/assets/ca8ce225-ba4f-4ac5-9445-60e1a8da8174)